### PR TITLE
Fix untranslated strings

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,7 +77,7 @@ const Home: React.FC = () => {
           <Box>
             <Link href="/levels/new">
               <Flex mt={[6, 6, 6, 6, 8]} align="center" justify="center" color="potato" gap={2}>
-                <Heading fontSize="1.2em">もっと見る</Heading>
+                <Heading fontSize="1.2em">{t.TOP_PAGE.LOAD_MORE}</Heading>
                 <Box fontSize="1.2em">
                   <FiArrowRight />
                 </Box>


### PR DESCRIPTION
## 📝 Description
「もっと見る」 is untranslated as raw string hardcoded in the template file.

## 🚀 New behavior
「もっと見る」 become 「Load More...」「もっと読み込む…」「加载更多」respectively
-

## 🔍 What should reviewers check?
Whether  「もっと見る」 is syntactically equivalent to 「もっと読み込む…」 or not, if not, then we should create a new string with 「もっと見る」.

Also the fact that, ``t.TOP_PAGE.LOAD_MORE`` is not assigned anywhere now.
- [ ]